### PR TITLE
fix: remove comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
                         "type": "integer",
                         "default": 2000,
                         "markdownDescription": "Delay calculation of code diagnostics after modifications in source. In milliseconds, default 2000 ms."
-                    },
+                    }
                 }
             }
         ]


### PR DESCRIPTION
This comma causes validation errors.


```
npm error code EJSONPARSE
npm error path /**/vscode-c3/package.json
npm error JSON.parse Expected double-quoted property name in JSON at position 3438 (line 97 column 17) while parsing near "... },\n                }\n            }\n    ..."
npm error JSON.parse Failed to parse JSON data.
npm error JSON.parse Note: package.json must be actual JSON, not just JavaScript.
```