### PR TITLE
fix: switch block/expression order

### DIFF
--- a/syntaxes/c3.tmLanguage.json
+++ b/syntaxes/c3.tmLanguage.json
@@ -1412,13 +1412,13 @@
           "include": "#control_statements"
         },
         {
-          "include": "#block"
-        },
-        {
           "include": "#declaration"
         },
         {
           "include": "#expression"
+        },
+        {
+          "include": "#block"
         }
       ]
     },

--- a/syntaxes/c3.tmLanguage.yml
+++ b/syntaxes/c3.tmLanguage.yml
@@ -715,9 +715,9 @@ repository:
 
       - include: "#control_statements"
 
-      - include: "#block"
       - include: "#declaration"
       - include: "#expression"
+      - include: "#block"
 
   variable:
     match: '(?<!#)\$?\b{{IDENT}}\b'


### PR DESCRIPTION
I noticed a situation where `meta.block.c3` nesting was getting messed up.

For example in in this code:
```c3
fn void! loadShader() {
    g_vertexShader = createShaderModule(&VERTEX_CODE)!;
    g_fragmentShader = createShaderModule(&FRAGMENT_CODE)!;
    g_vertexShaderStageInfo[0] = {
        .sType = vk::STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
        .stage = vk::ShaderStageFlags { .vertex },
        .module_ = g_vertexShader,
        .pName = "main",
    };
    g_vertexShaderStageInfo[1] = {
        .sType = vk::STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
        .stage = vk::ShaderStageFlags { .fragment },
        .module_ = g_fragmentShader,
        .pName = "main",
    };
}
```

Inside the function i got this:
```
punctuation.section.block.begin.c3
meta.block.c3
meta.function.c3
source.c3
```

Inside next initializer list block i got that:
```
meta.block.c3
meta.block.c3
meta.function.c3
source.c3
```

This is correct so far. But then inside `{ .vertex }` it did not increase the nesting of `meta.block.c3` anymore and after that point the blocks were not all blocks were closed.

The problem turned out to be that inside `statement` it matched a `block` before `expression` so it took that as a `block` instead of `initializer_list` which is an expression.