### PR TITLE
fix: remove redundant 'var' section from declaration and add path instead

### DIFF
--- a/syntaxes/c3.tmLanguage.json
+++ b/syntaxes/c3.tmLanguage.json
@@ -1201,29 +1201,6 @@
     "declaration": {
       "patterns": [
         {
-          "begin": "\\bvar\\b",
-          "beginCaptures": {
-            "0": {
-              "name": "storage.type.var.c3"
-            }
-          },
-          "end": ";",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.terminator.c3"
-            }
-          },
-          "patterns": [
-            {
-              "match": "\\$(?:_*[A-Z][_A-Z0-9]*[a-z][_a-zA-Z0-9]*)",
-              "name": "support.type.c3"
-            },
-            {
-              "include": "#declaration_after_type"
-            }
-          ]
-        },
-        {
           "begin": "(?=\\$(typeof|typefrom|vatype|evaltype)\\b)",
           "end": ";",
           "endCaptures": {
@@ -1239,6 +1216,9 @@
               "include": "#declaration_after_type"
             }
           ]
+        },
+        {
+          "include": "#path"
         },
         {
           "begin": "(?=\\$?\\b(?:_*[A-Z][_A-Z0-9]*[a-z][_a-zA-Z0-9]*)\\b|\\b(?:void|bool|char|double|float|float16|int128|ichar|int|iptr|isz|long|short|uint128|uint|ulong|uptr|ushort|usz|float128|any|anyfault|typeid)\\b)",

--- a/syntaxes/c3.tmLanguage.yml
+++ b/syntaxes/c3.tmLanguage.yml
@@ -619,17 +619,6 @@ repository:
 
   declaration:
     patterns:
-      - begin: \bvar\b
-        beginCaptures:
-          0: { name: storage.type.var.c3 }
-        end: ;
-        endCaptures:
-          0: { name: punctuation.terminator.c3 }
-        patterns:
-          # CT type
-          - match: '\${{TYPE}}'
-            name: support.type.c3
-          - include: "#declaration_after_type"
       - begin: '(?=\$(typeof|typefrom|vatype|evaltype)\b)'
         end: ;
         endCaptures:
@@ -637,6 +626,7 @@ repository:
         patterns:
           - include: "#type"
           - include: "#declaration_after_type"
+      - include: "#path"
       - begin: '(?=\$?\b{{TYPE}}\b|\b(?:{{base_type}})\b)'
         end: ;
         endCaptures:


### PR DESCRIPTION
Added `path` include to declaration to match module path before module name, ie: `glfw::Window* g_window;` in top level scope.

Also removed `var` match from declaration as i don't think there is such keyword on c3? If so then It was probably remnant from earlier times of the language (or from some other language).


