### PR TITLE
fix: added back var pattern

### DIFF
--- a/syntaxes/c3.tmLanguage.json
+++ b/syntaxes/c3.tmLanguage.json
@@ -1201,6 +1201,29 @@
     "declaration": {
       "patterns": [
         {
+          "begin": "\\bvar\\b",
+          "beginCaptures": {
+            "0": {
+              "name": "storage.type.var.c3"
+            }
+          },
+          "end": ";",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.terminator.c3"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\$(?:_*[A-Z][_A-Z0-9]*[a-z][_a-zA-Z0-9]*)",
+              "name": "support.type.c3"
+            },
+            {
+              "include": "#declaration_after_type"
+            }
+          ]
+        },
+        {
           "begin": "(?=\\$(typeof|typefrom|vatype|evaltype)\\b)",
           "end": ";",
           "endCaptures": {

--- a/syntaxes/c3.tmLanguage.yml
+++ b/syntaxes/c3.tmLanguage.yml
@@ -619,6 +619,17 @@ repository:
 
   declaration:
     patterns:
+      - begin: \bvar\b
+        beginCaptures:
+          0: { name: storage.type.var.c3 }
+        end: ;
+        endCaptures:
+          0: { name: punctuation.terminator.c3 }
+        patterns:
+          # CT type
+          - match: '\${{TYPE}}'
+            name: support.type.c3
+          - include: "#declaration_after_type"
       - begin: '(?=\$(typeof|typefrom|vatype|evaltype)\b)'
         end: ;
         endCaptures:


### PR DESCRIPTION
adding back `var` keyword syntax that was remove as part of https://github.com/c3lang/vscode-c3/pull/14