### PR TITLE
feat: some v0.7 syntax updates

### DIFF
--- a/syntaxes/c3.tmLanguage.json
+++ b/syntaxes/c3.tmLanguage.json
@@ -1085,7 +1085,7 @@
           ]
         },
         {
-          "match": "@(param(\\s*\\[&?(in|out|inout)\\])?|return!?|require|fails|deprecated|ensure|pure)\\s",
+          "match": "@(param(\\s*\\[&?(in|out|inout)\\])?|return[?]?|require|fails|deprecated|ensure|pure)\\s",
           "name": "markup.bold"
         }
       ]

--- a/syntaxes/c3.tmLanguage.json
+++ b/syntaxes/c3.tmLanguage.json
@@ -108,7 +108,7 @@
           "include": "#function"
         },
         {
-          "begin": "\\b(?:def|distinct)\\b",
+          "begin": "\\b(?:alias|typedef)\\b",
           "beginCaptures": {
             "0": {
               "name": "keyword.declaration.type.c3"
@@ -801,7 +801,7 @@
           "name": "keyword.control.ct.c3"
         },
         {
-          "match": "\\b(?:assert|asm|catch|const|def|distinct|extern|tlocal|inline|import|module|interface|static|try|var)\\b",
+          "match": "\\b(?:alias|assert|asm|catch|const|extern|tlocal|inline|import|module|interface|static|try|typedef|var)\\b",
           "name": "keyword.other.c3"
         },
         {


### PR DESCRIPTION
Nowhere close to every change required for v0.7, but I can help a little :)

- `@return?` syntax
- `alias` and `typedef` keywords
