### PR TITLE
chore: remove unnecessary activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "publisher": "c3",
     "repository": "https://github.com/c3lang/vscode-c3.git",
     "version": "0.1.6",
-    "activationEvents": [
-        "onLanguage:c3"
-    ],
     "engines": {
         "vscode": "^1.75.0"
     },


### PR DESCRIPTION
I got the following warning in VS Code:

> This activation event can be removed as VS Code generates these automatically from your package.json contribution declarations.

So I removed the activationEvents array.
