### PR TITLE
chore: mark c3.tmLanguage.json as readonly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.readonlyInclude": {
+    "syntaxes/c3.tmLanguage.json": true
+  }
+}


### PR DESCRIPTION
Since the `.json` file is generated, prevent contributors from editing it directly.

This only affects VS Code users.
