### PR TITLE
PoC Code Formatting Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,16 @@
                         "type": "integer",
                         "default": 2000,
                         "markdownDescription": "Delay calculation of code diagnostics after modifications in source. In milliseconds, default 2000 ms."
+                    },
+                    "c3.format.enable": {
+                        "type": "boolean",
+                        "default": false,
+                        "markdownDescription": "Enables formatting (via `clang-format`, see [clang.llvm.org](https://clang.llvm.org/docs/ClangFormat.html))"
+                    },
+                    "c3.format.path": {
+                        "type": "string",
+                        "default": null,
+                        "markdownDescription": "The path to `clang-format` binary (default: `clang-format` in `PATH`)"
                     }
                 }
             }

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,8 +1,10 @@
 import { activate as activateLS, deactivate as deactivateLS } from './lsp';
 import { setupC3 } from './setupC3';
+import { setupFormat } from './format';
 
 export async function activate(context) {
     await setupC3(context);
+    await setupFormat(context);
     activateLS(context);
 }
 

--- a/src/format.js
+++ b/src/format.js
@@ -1,0 +1,67 @@
+import vscode from "vscode";
+import { spawn } from "child_process";
+
+function runClangFormat(text, fileName, formatterPath = "clang-format") {
+    return new Promise((resolve, reject) => {
+        const args = [];
+
+        if (fileName) {
+            args.push("-assume-filename", fileName);
+        }
+
+        const proc = spawn(formatterPath, args);
+
+        let stdout = "";
+        let stderr = "";
+
+        proc.stdout.on("data", (data) => (stdout += data));
+        proc.stderr.on("data", (data) => (stderr += data));
+
+        proc.on("error", reject);
+
+        proc.on("close", (code) => {
+            if (code !== 0) {
+                return reject(new Error(`clang-format exited with code ${code}: ${stderr}`));
+            }
+
+            resolve(stdout);
+        });
+
+        proc.stdin.end(text);
+    });
+}
+
+export async function setupFormat(context) {
+    const fmtConfig = vscode.workspace.getConfiguration("c3.format");
+    const fmtPath = fmtConfig.get("path") || "clang-format";
+
+    context.subscriptions.push(
+        // Format full document
+        vscode.languages.registerDocumentFormattingEditProvider(
+            [
+                { language: "c3", scheme: "file" },     // files on disk
+                { language: "c3", scheme: "untitled" }, // unsaved files
+            ], {
+                async provideDocumentFormattingEdits(document) {
+                    try {
+                        const input = document.getText();
+                        const result = await runClangFormat(input, document.fileName, fmtPath);
+
+                        const fullRange = new vscode.Range(
+                            document.positionAt(0),
+                            document.positionAt(input.length)
+                        );
+
+                        return [
+                            vscode.TextEdit.replace(fullRange, result)
+                        ];
+                    } catch (err) {
+                        vscode.window.showErrorMessage(
+                            `Error formatting c3 document: ${err.message}`
+                        );
+                        return [];
+                    }
+                }
+        })
+    );
+}


### PR DESCRIPTION
Uses [clang-format](https://clang.llvm.org/docs/ClangFormat.html).

I need to dog-food this for a while to see how well it works. Feedback/testing welcome.

### TODO & Future Work:

- [ ] Validate that clang-format handles c3 properly/consistently
- [ ] Add support for formatting selection
  - Use clang-format's `-offset` and `-length` options
  - Can pass one `-offset` / `-length` pair for each selection
- [ ] Add support for saving/updating/restoring (multiple) cursors
  - clang-format supports only one cursor via `-cursor` option
  - It might be complicated (ie. patching) to properly handle multiple cursors
- [ ] Add support for saving/updating/restoring (multiple) selections
- [ ] Create a default `.clang-format` file which has c3's code style as a
      fallback if user provided no overriding `.clang-format` file.

**Note:** `package-lock.json` got updated during development but I didn't include it in the changes. AFAIK it's supposed to be tracked in VCS but the changes to it seem less relevant to these changes and more relevant to the VSCode I have installed on my computer.

Closes #7 
